### PR TITLE
Setup Maven tests with Surefire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/*
 *.project
 .idea/*
 *.iml
+surefire-reports/

--- a/c.bat
+++ b/c.bat
@@ -1,4 +1,0 @@
-call mvn clean
-call mvn eclipse:clean
-call mvn install
-call mvn eclipse:eclipse

--- a/pom.xml
+++ b/pom.xml
@@ -21,4 +21,17 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+				<configuration>
+					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
 			<version>5.9.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.9.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Remove `c.bat` and configure Maven Surefire plugin.

* **Remove `c.bat`**
  - Delete `c.bat` file from the repository.

* **Configure Maven Surefire plugin**
  - Add Surefire plugin configuration to `pom.xml` under `<build>` section to generate test reports.
  - Add `surefire-reports/` directory to `.gitignore` to ignore Surefire reports directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/derealizer?shareId=ff560b4d-0ae7-4121-aca8-a134dba5fd27).